### PR TITLE
Add tuner tab combining tuning controls and RDS summary

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="refresh_spectrum">Refresh Spectrum</string>
     <string name="server">Server</string>
     <string name="frequency">Frequency</string>
+    <string name="tuner">Tuner</string>
     <string name="status">Status</string>
     <string name="controls">Controls</string>
     <string name="rds">RDS</string>


### PR DESCRIPTION
## Summary
- add a dedicated Tuner tab that combines the existing frequency dials with key RDS fields
- refactor the frequency and RDS composables so they can be reused in multiple sections
- introduce a string resource for the new tab label

## Testing
- `ANDROID_HOME=/workspace/android-sdk ./gradlew build --console=plain` *(fails: Android SDK directory is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c06fd398832fae3b57caf70aedb8