### PR TITLE
Preserve tuner data when disconnecting

### DIFF
--- a/android/app/src/main/java/org/fmdx/app/MainViewModel.kt
+++ b/android/app/src/main/java/org/fmdx/app/MainViewModel.kt
@@ -186,14 +186,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         controller?.stop()
         controller?.clearMediaItems()
         _uiState.update { currentState ->
-            UiState(
-                serverUrl = currentState.serverUrl,
-                signalUnit = currentState.signalUnit,
-                networkBuffer = currentState.networkBuffer,
-                playerBuffer = currentState.playerBuffer,
-                restartAudioOnTune = currentState.restartAudioOnTune,
-                spectrum = baselineSpectrum(),
-                statusMessage = "Disconnected"
+            currentState.copy(
+                isConnected = false,
+                isConnecting = false,
+                audioPlaying = false,
+                isScanning = false,
+                statusMessage = "Disconnected",
+                errorMessage = null
             )
         }
     }


### PR DESCRIPTION
## Summary
- keep existing tuner and spectrum information visible after disconnecting by copying the prior UI state
- reset connection flags, scanning, and audio playback without clearing content so other tabs remain usable offline

## Testing
- ./gradlew test --console=plain *(fails: Android SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cf116438832f82440e4c33fa3846