### PR TITLE
Remove decimal point from decimal picker display

### DIFF
--- a/android/app/src/main/java/org/fmdx/app/MainActivity.kt
+++ b/android/app/src/main/java/org/fmdx/app/MainActivity.kt
@@ -492,7 +492,7 @@ private fun FrequencyControlsCard(
 
     val decimalDisplayValues = remember(stepKHz) {
         Array(decimalSteps) { index ->
-            String.format(Locale.ROOT, ".%02d", (index * stepKHz) / 10)
+            String.format(Locale.ROOT, "%02d", (index * stepKHz) / 10)
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the leading decimal point from the decimal frequency picker so the right wheel shows values like 10 instead of .10 while retaining the existing tuning step

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2d3d247bc832f8d9f9972684ea7c8