### PR TITLE
Clarify Android build steps after verifying debug assembly

### DIFF
--- a/android/app/AGENTS.md
+++ b/android/app/AGENTS.md
@@ -1,5 +1,4 @@
 # Android App Agent Instructions
-
 - Prefer stable, non-deprecated Android and Kotlin APIs. If a deprecated symbol is unavoidable,
   document why in code comments and look for an alternative first.
 - Align new Gradle or manifest configuration with the module's existing compile and target SDK (
@@ -8,3 +7,34 @@
   concurrency friendly.
 - Update or add automated checks (lint, unit tests) relevant to changes in this module when
   introducing new functionality.
+
+## Building the Project
+To build and install the Android app locally, follow these steps from the repository root:
+
+1. Install the Android SDK (API level 36.1) and ensure that `ANDROID_HOME` or `ANDROID_SDK_ROOT`
+   points at it. The build expects the preview platform and tools, so confirm these packages are
+   present (use `sdkmanager --sdk_root="$ANDROID_SDK_ROOT"` if needed):
+   - `platforms;android-36.1`
+   - `build-tools;36.1.0`
+   - `platform-tools`
+2. Prime the Gradle wrapper (downloads the wrapper JAR and distribution if missing):
+   ```bash
+   ./gradlew --version
+   ```
+3. Build the debug APK (first run may take ~9 minutes while the Kotlin compiler falls back to a
+   non-daemon mode and emits cache-closing warnings):
+   ```bash
+   ./gradlew assembleDebug
+   ```
+   The resulting artifact is written to `android/app/build/outputs/apk/debug/app-debug.apk`. During
+   the build you may also see `Unable to strip … libandroidx.graphics.path.so`; this is expected and
+   the library is packaged as-is.
+4. (Optional) Install the debug build on a connected device or running emulator:
+   ```bash
+   ./gradlew installDebug
+   ```
+5. If the Kotlin compiler continues to abort with cache errors on subsequent runs, stop any cached
+   daemons before retrying:
+   ```bash
+   ./gradlew --stop
+   ```


### PR DESCRIPTION
## Summary
- add verified Android SDK package prerequisites and Kotlin fallback context to android/app/AGENTS.md build instructions
- note the generated APK location, expected strip warnings, and daemon stop tip after assembling Debug

## Testing
- `./gradlew assembleDebug --console=plain --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68e417dc5d68832fab1d9005aa86034a