### PR TITLE
Enable swipe gestures between main tabs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui:1.9.2'
     implementation 'androidx.compose.ui:ui-graphics:1.9.2'
     implementation 'androidx.compose.ui:ui-tooling-preview:1.9.2'
+    implementation 'androidx.compose.foundation:foundation:1.9.2'
     implementation 'androidx.compose.material3:material3:1.4.0'
     implementation 'androidx.compose.material:material-icons-extended:1.7.8'
     debugImplementation 'androidx.compose.ui:ui-tooling:1.9.2'


### PR DESCRIPTION
## Summary
- add the Compose foundation dependency to access the pager components
- replace the tab content column with a HorizontalPager so tabs can be swiped while preserving connection gating

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e57406ff2c832f8327af7679c80a9b