### PR TITLE
Enable swipe navigation across main tabs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,6 +56,10 @@ android {
     lint {
         checkReleaseBuilds = false
     }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     buildToolsVersion '36.1.0'
 }
 
@@ -71,6 +75,8 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-tooling:1.9.2'
     debugImplementation 'androidx.compose.ui:ui-test-manifest:1.9.2'
 
+    implementation 'androidx.compose.foundation:foundation:1.9.2'
+
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
     implementation 'com.squareup.okhttp3:okhttp:5.1.0'
     implementation 'org.jsoup:jsoup:1.21.2'
@@ -80,4 +86,6 @@ dependencies {
     implementation 'androidx.media3:media3-exoplayer:1.8.0'
     implementation 'androidx.media3:media3-extractor:1.8.0'
     implementation 'androidx.media3:media3-session:1.8.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/app/src/test/java/org/fmdx/app/TabStateControllerTest.kt
+++ b/android/app/src/test/java/org/fmdx/app/TabStateControllerTest.kt
@@ -1,0 +1,50 @@
+package org.fmdx.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class TabStateControllerTest {
+
+    @Test
+    fun selectTabClampsWithinRange() {
+        val controller = TabStateController(pageCount = 3)
+
+        controller.selectTab(2)
+        assertEquals(2, controller.selectedTab)
+
+        controller.selectTab(10)
+        assertEquals(2, controller.selectedTab)
+
+        controller.selectTab(-5)
+        assertEquals(0, controller.selectedTab)
+    }
+
+    @Test
+    fun pagerChangeUpdatesSelectedTab() {
+        val controller = TabStateController(pageCount = 4)
+
+        controller.selectTab(1)
+        controller.onPagerPageChanged(3)
+
+        assertEquals(3, controller.selectedTab)
+    }
+
+    @Test
+    fun resetReturnsToFirstTab() {
+        val controller = TabStateController(pageCount = 5)
+
+        controller.selectTab(4)
+        controller.reset()
+
+        assertEquals(0, controller.selectedTab)
+    }
+
+    @Test
+    fun saverRestoresPreviousSelection() {
+        val restored = TabStateController.saver(pageCount = 6).restore(4)
+
+        assertNotNull(restored)
+        assertEquals(4, restored?.selectedTab)
+    }
+}


### PR DESCRIPTION
## Summary
- add a composable pager to the main screen so tabs can be swiped while keeping tab selection and connection state in sync
- introduce a TabStateController with a saveable implementation to manage tab selection and update Gradle dependencies for the pager
- cover the new tab state controller with unit tests to ensure tab selection clamps, resets, and restores correctly

## Testing
- ./gradlew testDebugUnitTest --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68e57406ff2c832f8327af7679c80a9b