### PR TITLE
Enable swipe navigation across main tabs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,6 +56,10 @@ android {
     lint {
         checkReleaseBuilds = false
     }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     buildToolsVersion '36.1.0'
 }
 
@@ -71,6 +75,8 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-tooling:1.9.2'
     debugImplementation 'androidx.compose.ui:ui-test-manifest:1.9.2'
 
+    implementation 'androidx.compose.foundation:foundation:1.9.2'
+
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
     implementation 'com.squareup.okhttp3:okhttp:5.1.0'
     implementation 'org.jsoup:jsoup:1.21.2'
@@ -80,4 +86,6 @@ dependencies {
     implementation 'androidx.media3:media3-exoplayer:1.8.0'
     implementation 'androidx.media3:media3-extractor:1.8.0'
     implementation 'androidx.media3:media3-session:1.8.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/app/src/main/java/org/fmdx/app/MainActivity.kt
+++ b/android/app/src/main/java/org/fmdx/app/MainActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -20,6 +22,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -60,8 +64,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -70,6 +76,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -82,8 +89,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import org.fmdx.app.model.SignalUnit
 import org.fmdx.app.model.SpectrumPoint
+import org.fmdx.app.model.TunerInfo
 import org.fmdx.app.model.TunerState
 import org.fmdx.app.ui.theme.FmDxTheme
 import java.util.Locale
@@ -179,7 +188,7 @@ private fun FmDxApp(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 private fun MainScreen(
     state: UiState,
@@ -199,7 +208,6 @@ private fun MainScreen(
     antennaLabel: () -> String,
     onShowSettings: () -> Unit
 ) {
-    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     val tabs = listOf(
         SectionTab(R.string.server) { ServerSection(state, onUpdateUrl, onConnect, onDisconnect) },
         SectionTab(R.string.tuner) { TunerSection(state, onTuneDirect, formatSignal, currentPty) },
@@ -216,11 +224,31 @@ private fun MainScreen(
         SectionTab(R.string.station) { StationSection(state) },
         SectionTab(R.string.spectrum) { SpectrumSection(state, onScan, onRefreshSpectrum) }
     )
+    val tabStateController = rememberSaveable(
+        inputs = arrayOf(tabs.size),
+        saver = TabStateController.saver(tabs.size)
+    ) {
+        TabStateController(tabs.size)
+    }
+    val selectedTab = tabStateController.selectedTab
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { tabs.size })
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
     LaunchedEffect(state.isConnected) {
         if (!state.isConnected) {
-            selectedTab = 0
+            tabStateController.reset()
+        }
+    }
+
+    LaunchedEffect(selectedTab) {
+        if (selectedTab != pagerState.currentPage) {
+            pagerState.animateScrollToPage(selectedTab)
+        }
+    }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collectLatest { page ->
+            tabStateController.onPagerPageChanged(page)
         }
     }
 
@@ -271,28 +299,38 @@ private fun MainScreen(
         ) {
             PrimaryScrollableTabRow(selectedTabIndex = selectedTab) {
                 tabs.forEachIndexed { index, tab ->
+                    val tabTag = "main_tab_${tab.titleRes}"
                     Tab(
+                        modifier = Modifier.testTag(tabTag),
                         selected = selectedTab == index,
-                        onClick = { selectedTab = index },
+                        onClick = { tabStateController.selectTab(index) },
                         text = { Text(text = stringResource(id = tab.titleRes)) },
                         enabled = index == 0 || state.isConnected
                     )
                 }
             }
-            Box(
+            HorizontalPager(
+                state = pagerState,
+                userScrollEnabled = state.isConnected,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                val scrollState = rememberScrollState()
-                Column(
+                    .testTag("main_sections_pager")
+            ) { page ->
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(scrollState),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                        .fillMaxSize()
+                        .padding(16.dp)
                 ) {
-                    tabs[selectedTab].content()
+                    val scrollState = rememberScrollState()
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(scrollState),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        tabs[page].content()
+                    }
                 }
             }
         }
@@ -341,6 +379,35 @@ private data class SectionTab(
     @param:StringRes val titleRes: Int,
     val content: @Composable () -> Unit
 )
+
+@VisibleForTesting
+internal class TabStateController(
+    private val pageCount: Int,
+    initialSelected: Int = 0
+) {
+    private var _selectedTab by mutableIntStateOf(initialSelected.coerceIn(0, maxOf(pageCount - 1, 0)))
+    val selectedTab: Int
+        get() = _selectedTab
+
+    fun selectTab(index: Int) {
+        _selectedTab = index.coerceIn(0, maxOf(pageCount - 1, 0))
+    }
+
+    fun onPagerPageChanged(page: Int) {
+        selectTab(page)
+    }
+
+    fun reset() {
+        _selectedTab = 0
+    }
+
+    companion object {
+        fun saver(pageCount: Int): Saver<TabStateController, Int> = Saver(
+            save = { it.selectedTab },
+            restore = { saved -> TabStateController(pageCount, saved) }
+        )
+    }
+}
 
 @Composable
 private fun ConnectionStatusIndicator(
@@ -393,52 +460,108 @@ private fun ServerSection(
     onConnect: () -> Unit,
     onDisconnect: () -> Unit
 ) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedTextField(
+                    value = state.serverUrl,
+                    onValueChange = onUpdateUrl,
+                    label = { Text(stringResource(id = R.string.server_url)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(
+                        imeAction = ImeAction.Done,
+                        keyboardType = KeyboardType.Uri
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { onConnect() })
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    if (state.isConnected) {
+                        OutlinedButton(onClick = onConnect, enabled = false) {
+                            Text(text = stringResource(id = R.string.connect))
+                        }
+                        Button(onClick = onDisconnect) {
+                            Text(text = stringResource(id = R.string.disconnect))
+                        }
+                    } else {
+                        Button(onClick = onConnect, enabled = !state.isConnecting) {
+                            Text(text = stringResource(id = R.string.connect))
+                        }
+                        OutlinedButton(onClick = onDisconnect, enabled = false) {
+                            Text(text = stringResource(id = R.string.disconnect))
+                        }
+                    }
+                }
+                if (state.isConnecting) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+                state.statusMessage?.let { message ->
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+        if (state.isConnected) {
+            ServerInfoCard(tunerInfo = state.tunerInfo)
+        }
+    }
+}
+
+@Composable
+private fun ServerInfoCard(tunerInfo: TunerInfo?) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            OutlinedTextField(
-                value = state.serverUrl,
-                onValueChange = onUpdateUrl,
-                label = { Text(stringResource(id = R.string.server_url)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(
-                    imeAction = ImeAction.Done,
-                    keyboardType = KeyboardType.Uri
-                ),
-                keyboardActions = KeyboardActions(onDone = { onConnect() })
+            Text(
+                text = stringResource(id = R.string.server_info_title),
+                style = MaterialTheme.typography.titleMedium
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                if (state.isConnected) {
-                    OutlinedButton(onClick = onConnect, enabled = false) {
-                        Text(text = stringResource(id = R.string.connect))
-                    }
-                    Button(onClick = onDisconnect) {
-                        Text(text = stringResource(id = R.string.disconnect))
-                    }
-                } else {
-                    Button(onClick = onConnect, enabled = !state.isConnecting) {
-                        Text(text = stringResource(id = R.string.connect))
-                    }
-                    OutlinedButton(onClick = onDisconnect, enabled = false) {
-                        Text(text = stringResource(id = R.string.disconnect))
-                    }
-                }
-            }
-            if (state.isConnecting) {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
-            state.tunerInfo?.let { info ->
-                Text(text = info.tunerDescription, style = MaterialTheme.typography.bodyMedium)
-            }
-            state.statusMessage?.let { message ->
+            if (tunerInfo == null) {
                 Text(
-                    text = message,
+                    text = stringResource(id = R.string.server_info_unavailable),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            } else {
+                Text(
+                    text = stringResource(
+                        id = R.string.server_info_tuner_name,
+                        tunerInfo.tunerName
+                    ),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = tunerInfo.tunerDescription,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                val activeAntennaName = tunerInfo.antennaNames.getOrNull(tunerInfo.activeAntenna)
+                if (activeAntennaName != null) {
+                    Text(
+                        text = stringResource(
+                            id = R.string.server_info_active_antenna,
+                            activeAntennaName
+                        ),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                if (tunerInfo.antennaNames.isNotEmpty()) {
+                    Text(
+                        text = stringResource(
+                            id = R.string.server_info_antennas,
+                            tunerInfo.antennaNames.joinToString(", ")
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -64,4 +64,9 @@
     <string name="kw_unit">%1$s kW</string>
     <string name="deg_unit">%1$s°</string>
     <string name="signal_label_prefix">"Signal: "</string>
+    <string name="server_info_title">Server information</string>
+    <string name="server_info_tuner_name">Tuner: %1$s</string>
+    <string name="server_info_active_antenna">Active antenna: %1$s</string>
+    <string name="server_info_antennas">Antennas: %1$s</string>
+    <string name="server_info_unavailable">No server details available.</string>
 </resources>

--- a/android/app/src/test/java/org/fmdx/app/TabStateControllerTest.kt
+++ b/android/app/src/test/java/org/fmdx/app/TabStateControllerTest.kt
@@ -1,0 +1,50 @@
+package org.fmdx.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class TabStateControllerTest {
+
+    @Test
+    fun selectTabClampsWithinRange() {
+        val controller = TabStateController(pageCount = 3)
+
+        controller.selectTab(2)
+        assertEquals(2, controller.selectedTab)
+
+        controller.selectTab(10)
+        assertEquals(2, controller.selectedTab)
+
+        controller.selectTab(-5)
+        assertEquals(0, controller.selectedTab)
+    }
+
+    @Test
+    fun pagerChangeUpdatesSelectedTab() {
+        val controller = TabStateController(pageCount = 4)
+
+        controller.selectTab(1)
+        controller.onPagerPageChanged(3)
+
+        assertEquals(3, controller.selectedTab)
+    }
+
+    @Test
+    fun resetReturnsToFirstTab() {
+        val controller = TabStateController(pageCount = 5)
+
+        controller.selectTab(4)
+        controller.reset()
+
+        assertEquals(0, controller.selectedTab)
+    }
+
+    @Test
+    fun saverRestoresPreviousSelection() {
+        val restored = TabStateController.saver(pageCount = 6).restore(4)
+
+        assertNotNull(restored)
+        assertEquals(4, restored?.selectedTab)
+    }
+}


### PR DESCRIPTION
## Summary
- add a composable pager to the main screen so tabs can be swiped while keeping tab selection and connection state in sync
- introduce a TabStateController with a saveable implementation to manage tab selection and update Gradle dependencies for the pager
- cover the new tab state controller with unit tests to ensure tab selection clamps, resets, and restores correctly
- show connected server details in a dedicated card on the server tab

## Testing
- ./gradlew testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e57406ff2c832f8327af7679c80a9b