### PR TITLE
Fix TEF Logger pass-through on direct USB tuners (v2.1.0)

### DIFF
--- a/android/fm-dx-app/build.gradle
+++ b/android/fm-dx-app/build.gradle
@@ -19,8 +19,8 @@ def runGit = { String... args ->
     def text = result.standardOutput.asText.get().trim()
     text.isEmpty() ? null : text
 }
-def FALLBACK_VERSION_CODE = 20001
-def FALLBACK_VERSION_NAME = "2.0.1"
+def FALLBACK_VERSION_CODE = 20100
+def FALLBACK_VERSION_NAME = "2.1.0"
 def resolvedVersionCode = runGit('rev-list', '--count', 'HEAD')?.toInteger() ?: FALLBACK_VERSION_CODE
 def resolvedVersionName = runGit('describe', '--tags', '--always', '--dirty')
     ?.replaceFirst(/^v/, '') ?: FALLBACK_VERSION_NAME

--- a/android/fm-dx-app/src/main/java/org/fmdx/app/MainViewModel.kt
+++ b/android/fm-dx-app/src/main/java/org/fmdx/app/MainViewModel.kt
@@ -594,7 +594,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun updatePassThroughServiceState() {
         val state = uiState.value
-        val url = state.serverUrl
+        // Use the raw session label (http(s)://… for a server, usb://… for a direct tuner).
+        // uiState.serverUrl hides transport labels, which would stop the service starting on USB.
+        val url = sessionController.state.value.serverUrl
         if (state.passThroughEnabled && state.isConnected && url.isNotBlank()) {
             PassThroughService.start(app, url)
         } else {

--- a/android/fm-dx-app/src/main/java/org/fmdx/app/telemetry/PassThroughService.kt
+++ b/android/fm-dx-app/src/main/java/org/fmdx/app/telemetry/PassThroughService.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.fmdx.app.BuildConfig
+import org.fmdx.app.FmDxApp
 import org.fmdx.app.MainActivity
 import org.fmdx.app.R
-import org.fmdx.app.data.ControlConnection
 import org.fmdx.app.data.FmDxRepository
 import org.fmdx.app.data.PluginConnection
 import org.fmdx.app.data.PluginTelemetryEvent
@@ -36,8 +36,9 @@ class PassThroughService : Service() {
     private val repository by lazy { FmDxRepository(okHttpClient) }
     private val telemetrySender by lazy { PassThroughTelemetrySender(this, serviceScope) }
 
-    private var controlConnection: ControlConnection? = null
+    private val sessionController by lazy { (application as FmDxApp).sessionController }
     private var pluginConnection: PluginConnection? = null
+    private var stateJob: Job? = null
     private var restartJob: Job? = null
     private var currentServerUrl: String? = null
 
@@ -76,17 +77,21 @@ class PassThroughService : Service() {
         stopConnections()
         telemetrySender.setFeatureEnabled(true)
         telemetrySender.onConnected(url)
-        controlConnection = repository.connectControl(
-            baseUrl = url,
-            userAgent = BuildConfig.USER_AGENT,
-            scope = serviceScope,
-            onState = { telemetrySender.updateTunerState(it) },
-            onClosed = { scheduleRestart() },
-            onError = { throwable ->
-                Log.w(TAG, "control socket error", throwable)
-                scheduleRestart()
+        // Tuner state comes from the process-wide session controller, so telemetry works for BOTH
+        // a remote fm-dx-webserver and a directly attached USB tuner (which has no server socket).
+        stateJob = serviceScope.launch {
+            sessionController.state.collect { session ->
+                session.tunerState?.let { telemetrySender.updateTunerState(it) }
             }
-        )
+        }
+        // GPS + scanner telemetry are fm-dx-webserver plugin features — server connections only.
+        if (url.startsWith("http", ignoreCase = true)) {
+            connectPlugin(url)
+        }
+    }
+
+    private fun connectPlugin(url: String) {
+        pluginConnection?.close()
         pluginConnection = repository.connectPlugin(
             baseUrl = url,
             userAgent = BuildConfig.USER_AGENT,
@@ -101,8 +106,8 @@ class PassThroughService : Service() {
     private fun stopConnections() {
         restartJob?.cancel()
         restartJob = null
-        controlConnection?.close()
-        controlConnection = null
+        stateJob?.cancel()
+        stateJob = null
         pluginConnection?.close()
         pluginConnection = null
         telemetrySender.setFeatureEnabled(false)
@@ -110,11 +115,13 @@ class PassThroughService : Service() {
     }
 
     private fun scheduleRestart() {
-        if (currentServerUrl.isNullOrBlank()) return
+        val url = currentServerUrl ?: return
+        // Only the plugin socket can drop; tuner state is driven by the session controller.
+        if (!url.startsWith("http", ignoreCase = true)) return
         if (restartJob?.isActive == true) return
         restartJob = serviceScope.launch {
             delay(RESTART_DELAY_MS)
-            currentServerUrl?.let { startConnections(it) }
+            connectPlugin(url)
         }
     }
 


### PR DESCRIPTION
## Summary
TEF Logger UDP pass-through previously only worked on the **network** path. This fixes it for
**direct USB tuners** while leaving the server behaviour unchanged.

Two root causes:
1. `PassThroughService` opened its **own** fm-dx-webserver control/plugin WebSocket to `serverUrl`
   — invalid for a `usb://` direct tuner. It now reads tuner state from the shared, process-wide
   `FmDxSessionController` (populated for both server and USB).
2. `updatePassThroughServiceState` used the **UI** `serverUrl`, which hides `usb://` labels, so the
   service never started on USB. It now uses the raw session label.

The GPS/scanner plugin socket is still opened only for `http(s)` server URLs (those are
fm-dx-webserver plugin features with no USB equivalent). Network telemetry — tuner CSV **plus**
GPS/scanner — is unchanged.

## Testing
- build + unit tests + Android Lint + detekt + markdownlint green.
- Installed on a Xiaomi Mi 9T Pro (Android 11) alongside TEF Logger 6.01 for end-to-end checks.

Minor release **2.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)